### PR TITLE
Fix: NTFS or ReFS check, ReFS would always return true

### DIFF
--- a/SetAppContainerACL.au3
+++ b/SetAppContainerACL.au3
@@ -649,7 +649,7 @@ Local $sFileSystem = DriveGetFileSystem($aDrives[0] & "\") ; Find the file syste
 For $i = UBound($aDrives) - 1 To 0 Step -1
 	Local $sFileSystem = DriveGetFileSystem($aDrives[$i] & "\")
 	;If $sFileSystem <> 'NTFS' Or 'ReFS' Then
-	If $sFileSystem = 'NTFS' Or 'ReFS' Then
+	If $sFileSystem = 'NTFS' Or $sFileSystem = 'ReFS' Then
 		;_ArrayDelete($aDrives, $i)
 		;MsgBox($MB_SYSTEMMODAL, "", "File System Type: " & $sFileSystem)
 	Else


### PR DESCRIPTION
This if statement would result in ReFS always being true, since AutoIt does not carry over the left hand comparison, fix just adds the comparison to the right side of Or also.